### PR TITLE
Use correct `umi-serializers` package.

### DIFF
--- a/packages/explorerkit-translator/package.json
+++ b/packages/explorerkit-translator/package.json
@@ -40,7 +40,6 @@
     "@metaplex-foundation/umi-serializers": "^0.8.5",
     "@solana/spl-type-length-value": "^0.1.0",
     "@solanafm/kinobi-lite": "^0.12.0",
-    "@solanafm/utils": "^1.0.4",
-    "change-case": "^5.4.2"
+    "@solanafm/utils": "^1.0.4"
   }
 }

--- a/packages/explorerkit-translator/src/helpers/KinobiTreeGenerator.ts
+++ b/packages/explorerkit-translator/src/helpers/KinobiTreeGenerator.ts
@@ -27,7 +27,7 @@ import {
   u64,
   u128,
   unit,
-} from "@metaplex-foundation/umi/serializers";
+} from "@metaplex-foundation/umi-serializers";
 import { splDiscriminate } from "@solana/spl-type-length-value";
 import {
   assertStructFieldTypeNode,

--- a/packages/explorerkit-translator/src/helpers/KinobiTreeGenerator.ts
+++ b/packages/explorerkit-translator/src/helpers/KinobiTreeGenerator.ts
@@ -51,9 +51,9 @@ import {
   TypeNode,
 } from "@solanafm/kinobi-lite";
 import { encodeBase58 } from "@solanafm/utils";
-import { snakeCase } from "change-case";
 
 import { FMShankSerializer, KinobiTreeGeneratorType, ShankSerializer } from "../types/KinobiTreeGenerator";
+import { toSnakeCase } from "./common";
 
 export class KinobiTreeGenerator {
   public rootNode: RootNode;
@@ -208,7 +208,7 @@ export class KinobiTreeGenerator {
 
                 if (interfaceDiscriminantMode) {
                   // Will convert to snake case for now since all the discriminators are made from snake-cases
-                  const ixName = snakeCase(instructionNode.name);
+                  const ixName = toSnakeCase(instructionNode.name);
                   const discriminant = splDiscriminate(`${interfacePrefixString ?? ""}:${ixName}`);
                   instructionLayout.set(encodeBase58(discriminant), fmShankSerializer);
                 } else {

--- a/packages/explorerkit-translator/src/helpers/common.ts
+++ b/packages/explorerkit-translator/src/helpers/common.ts
@@ -1,0 +1,6 @@
+export const toSnakeCase = (str: string) => {
+  return str
+    .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+    .map(x => x.toLowerCase())
+    .join('_');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,9 +151,6 @@ importers:
       '@solanafm/utils':
         specifier: ^1.0.4
         version: 1.0.4
-      change-case:
-        specifier: ^5.4.2
-        version: 5.4.2
     devDependencies:
       '@solana/web3.js':
         specifier: ^1.87.2
@@ -1709,10 +1706,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  /change-case@5.4.2:
-    resolution: {integrity: sha512-WB3UiTDpT+vrTilAWaJS4gaIH/jc1He4H9f6erQvraUYas90uWT0JOYFkG1imdNv710XJ6gJvqynrgOHc4ihDA==}
-    dev: false
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}


### PR DESCRIPTION
Builds fail when referencing the old umi serializers import path of `@metaplex-foundation/umi/serializers`, which should be `@metaplex-foundation/umi-serializers`