### PR TITLE
feat: Create error parser for anchorV1 IdlItem as well

### DIFF
--- a/packages/explorerkit-translator/src/interfaces/ErrorParserInterface.ts
+++ b/packages/explorerkit-translator/src/interfaces/ErrorParserInterface.ts
@@ -18,6 +18,7 @@ export interface ErrorParserInterface {
 export const createErrorParser = (idlItem: IdlItem) => {
   switch (idlItem.idlType) {
     case "anchor":
+    case "anchorV1":
       return createAnchorErrorParser(idlItem);
     case "shank":
       return createShankErrorParser(idlItem);


### PR DESCRIPTION
 Currently, the AnchorV1 IDLs lack error parsing capabilities, even though errors are defined within their IDL.